### PR TITLE
Wheel speed adjustment

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -21,7 +21,8 @@ public class Navigation
     final double ROTATION_RAMP_DISTANCE = Math.PI / 4;  // Radians
     final double MAX_STRAFE_POWER = 0.75;
     final double MIN_STRAFE_POWER = 0.1;
-    final double ROTATION_POWER = 0.375;  // Power to use while rotating.
+    final double MAX_ROTATION_POWER = 0.375;
+    final double MIN_ROTATION_POWER = 0.05;
     // Accepted amounts of deviation between the robot's desired position and actual position.
     final double EPSILON_LOC = 0.1;
     final double EPSILON_ANGLE = 0.1;
@@ -202,7 +203,7 @@ public class Navigation
             rotationSize = 2 * Math.PI - rotationSize;
         }
 
-        double power = 0;
+        double power = MIN_ROTATION_POWER;
         double rotationProgress = Math.abs(currentRotation - startingRotation);
         while (Math.abs(targetRotation - currentRotation) > EPSILON_ANGLE) {
             robot.positionManager.updatePosition(robot);
@@ -211,17 +212,28 @@ public class Navigation
             if (rotationProgress < rotationSize / 2) {
                 // Ramping up.
                 if (rotationProgress <= ROTATION_RAMP_DISTANCE) {
-                    power = (rotationProgress / ROTATION_RAMP_DISTANCE) * ROTATION_POWER;
+                    power = Range.clip(
+                            (rotationProgress / ROTATION_RAMP_DISTANCE) * MAX_ROTATION_POWER,
+                            MIN_ROTATION_POWER, MAX_ROTATION_POWER);
                 }
             }
             else {
                 // Ramping down.
                 if (rotationProgress >= rotationSize - ROTATION_RAMP_DISTANCE) {
-                    power = ((rotationSize - rotationProgress) / ROTATION_RAMP_DISTANCE) * ROTATION_POWER;
+                    power = Range.clip(
+                            ((rotationSize - rotationProgress) / ROTATION_RAMP_DISTANCE) * MAX_ROTATION_POWER,
+                            MIN_ROTATION_POWER, MAX_ROTATION_POWER);
                 }
             }
 
-            setDriveMotorPowers(0.0, 0.0, power, robot);
+            switch (direction) {
+                case CLOCKWISE:
+                    setDriveMotorPowers(0.0, 0.0, power, robot);
+                    break;
+                case COUNTERCLOCKWISE:
+                    setDriveMotorPowers(0.0, 0.0, -power, robot);
+                    break;
+            }
         }
 
         stopMovement(robot);
@@ -246,13 +258,17 @@ public class Navigation
             if (distanceTraveled < totalDistance / 2) {
                 // Ramping up.
                 if (distanceTraveled <= STRAFE_RAMP_DISTANCE) {
-                    power = (distanceTraveled / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER;
+                    power = Range.clip(
+                            (distanceTraveled / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER,
+                            MIN_STRAFE_POWER, MAX_STRAFE_POWER);
                 }
             }
             else {
                 // Ramping down.
                 if (distanceTraveled >= totalDistance - STRAFE_RAMP_DISTANCE) {
-                    power = ((totalDistance - distanceTraveled) / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER;
+                    power = Range.clip(
+                            ((totalDistance - distanceTraveled) / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER,
+                            MIN_STRAFE_POWER, MAX_STRAFE_POWER);
                 }
             }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -20,7 +20,7 @@ public class Navigation
     final double STRAFE_RAMP_DISTANCE = 10.0;  // Inches
     final double ROTATION_RAMP_DISTANCE = Math.PI / 4;  // Radians
     final double MAX_STRAFE_POWER = 0.75;
-     final double MIN_STRAFE_POWER = 0.1;
+    final double MIN_STRAFE_POWER = 0.1;
     final double ROTATION_POWER = 0.375;  // Power to use while rotating.
     // Accepted amounts of deviation between the robot's desired position and actual position.
     final double EPSILON_LOC = 0.1;
@@ -35,6 +35,10 @@ public class Navigation
     final double FINE_ROTATION_POWER = 0.1;
 
     public enum RotationDirection {CLOCKWISE, COUNTERCLOCKWISE}
+
+    // Speeds relative to one another.
+    //                              RL   RR   FL   FR
+    static double[] wheel_speeds = {1.0, 1.0, 1.0, 1.0};
 
     // First position in this ArrayList is the first position that robot is planning to go to.
     // This condition must be maintained (positions should be deleted as the robot travels)
@@ -296,21 +300,20 @@ public class Navigation
         double sinMoveDirection = Math.sin(strafeDirection);
         double cosMoveDirection = Math.cos(strafeDirection);
 
-
         double powerSet1 = sinMoveDirection + cosMoveDirection;
         double powerSet2 = sinMoveDirection - cosMoveDirection;
-        double [] rawPowers=scaleRange(powerSet1,powerSet2);
+        double [] rawPowers = scaleRange(powerSet1, powerSet2);
 
-
-        robot.driveMotors.get(RobotConfig.DriveMotors.REAR_LEFT).setPower(rawPowers[1] * power + turn);
-        robot.driveMotors.get(RobotConfig.DriveMotors.REAR_RIGHT).setPower(rawPowers[0] * power - turn);
-        robot.driveMotors.get(RobotConfig.DriveMotors.FRONT_LEFT).setPower(rawPowers[0] * power + turn);
-        robot.driveMotors.get(RobotConfig.DriveMotors.FRONT_RIGHT).setPower(rawPowers[1] * power - turn);
+        robot.driveMotors.get(RobotConfig.DriveMotors.REAR_LEFT).setPower((rawPowers[1] * power + turn) * wheel_speeds[0]);
+        robot.driveMotors.get(RobotConfig.DriveMotors.REAR_RIGHT).setPower((rawPowers[0] * power - turn) * wheel_speeds[1]);
+        robot.driveMotors.get(RobotConfig.DriveMotors.FRONT_LEFT).setPower((rawPowers[0] * power + turn) * wheel_speeds[2]);
+        robot.driveMotors.get(RobotConfig.DriveMotors.FRONT_RIGHT).setPower((rawPowers[1] * power - turn) * wheel_speeds[3]);
 
         robot.telemetry.addData("Front Motors", "left (%.2f), right (%.2f)",
-                rawPowers[0] * power, rawPowers[1] * power);
+                (rawPowers[0] * power + turn) * wheel_speeds[2], (rawPowers[1] * power - turn) * wheel_speeds[3]);
         robot.telemetry.addData("Rear Motors", "left (%.2f), right (%.2f)",
-                rawPowers[1] * power, rawPowers[0] * power);
+                (rawPowers[1] * power + turn) * wheel_speeds[0], (rawPowers[0] * power - turn) * wheel_speeds[1]);
+        robot.telemetry.update();
     }
 
     /** Sets all drivetrain motor powers to zero.

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
@@ -102,6 +102,43 @@ public class RobotManager {
             robot.fineRotation = !robot.fineRotation;
         }
 
+        // Adjust relative wheel speeds.
+
+        // Left stick Y for adjusting rear left.
+        if (gamepads.getJoystickValues().gamepad2LeftStickY > 0.1) {
+            Navigation.wheel_speeds[0] += 0.01;
+        }
+        else if (gamepads.getJoystickValues().gamepad2LeftStickY < 0.1) {
+            Navigation.wheel_speeds[0] -= 0.01;
+        }
+        // Left stick X for adjusting rear right.
+        if (gamepads.getJoystickValues().gamepad2LeftStickX > 0.1) {
+            Navigation.wheel_speeds[1] += 0.01;
+        }
+        else if (gamepads.getJoystickValues().gamepad2LeftStickX < 0.1) {
+            Navigation.wheel_speeds[1] -= 0.01;
+        }
+        // Right stick Y for adjusting front left.
+        if (gamepads.getJoystickValues().gamepad2RightStickY > 0.1) {
+            Navigation.wheel_speeds[2] += 0.01;
+        }
+        else if (gamepads.getJoystickValues().gamepad2RightStickY < 0.1) {
+            Navigation.wheel_speeds[2] -= 0.01;
+        }
+        // Right stick X for adjusting front right.
+        if (gamepads.getJoystickValues().gamepad2RightStickX > 0.1) {
+            Navigation.wheel_speeds[3] += 0.01;
+        }
+        else if (gamepads.getJoystickValues().gamepad2RightStickX < 0.1) {
+            Navigation.wheel_speeds[3] -= 0.01;
+        }
+
+        robot.telemetry.addData("Front Motor Relative Speeds", "left (%.2f), right (%.2f)",
+                Navigation.wheel_speeds[2], Navigation.wheel_speeds[3]);
+        robot.telemetry.addData("Rear Motor Relative Speeds", "left (%.2f), right (%.2f)",
+                Navigation.wheel_speeds[0], Navigation.wheel_speeds[1]);
+        robot.telemetry.update();
+
         previousStateGamepads.copyGamepads(gamepads);
     }
 


### PR DESCRIPTION
- Allows the relative scaling of wheel speeds to be adjusted from the Gamepad 2 joysticks and displays this info as telemetry
- Fixes issue in autonomous navigation methods: scaling speed by distance from the starting location means the speed will remain zero forever. Solves this issue by clipping the value to a minimum.