### PR TITLE
Use left trigger as throttle input

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GamepadWrapper.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/GamepadWrapper.java
@@ -5,7 +5,6 @@ package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.exception.RobotCoreException;
 import com.qualcomm.robotcore.hardware.Gamepad;
-import com.qualcomm.robotcore.util.Range;
 
 /** Wraps a gamepad so that button mappings are stored in one place.
  */
@@ -13,7 +12,7 @@ public class GamepadWrapper {
     public enum DriverAction {START_STOP_CAROUSEL, SET_SLIDES_RETRACTED, SET_SLIDES_L1, SET_SLIDES_L2, SET_SLIDES_L3,
                               SET_SLIDES_CAPPING, OPEN_CLAW, CLOSE_CLAW, CHANGE_MOVEMENT_MODE,
                               CHANGE_ROTATION_MODE, MOVE_STRAIGHT_FORWARD, MOVE_STRAIGHT_BACKWARD, MOVE_STRAIGHT_LEFT,
-                              MOVE_STRAIGHT_RIGHT}
+                              MOVE_STRAIGHT_RIGHT, SET_STRAFE_POWER}
 
     Gamepad gamepad1, gamepad2;
 
@@ -74,21 +73,24 @@ public class GamepadWrapper {
         return false;
     }
 
-    /** Returns the x and y coordinates of each of the 4 joysticks.
+    /** Returns the x and y coordinates of each of the 4 joysticks as well as the values of each trigger.
      */
-    public JoystickValues getJoystickValues() {
-        return new JoystickValues(gamepad1, gamepad2);
+    public AnalogValues getAnalogValues() {
+        return new AnalogValues(gamepad1, gamepad2);
     }
 }
 
 
-/** Stores 8 joystick values (an x and y coordinate for each of 4 sticks across 2 gamepads).
+/** Stores 8 analog values on the gamepad:
+ *   - An x and y coordinate for each of 4 sticks across 2 gamepads
+ *   - Each of the 4 triggers
  */
-class JoystickValues {
+class AnalogValues {
     public double gamepad1RightStickX, gamepad1RightStickY, gamepad1LeftStickX, gamepad1LeftStickY,
-                  gamepad2RightStickX, gamepad2RightStickY, gamepad2LeftStickX, gamepad2LeftStickY;
+                  gamepad2RightStickX, gamepad2RightStickY, gamepad2LeftStickX, gamepad2LeftStickY,
+                  gamepad1LeftTrigger, gamepad1RightTrigger, gamepad2LeftTrigger, gamepad2RightTrigger;
 
-    public JoystickValues(Gamepad gamepad1, Gamepad gamepad2) {
+    public AnalogValues(Gamepad gamepad1, Gamepad gamepad2) {
         this.gamepad1RightStickX = gamepad1.right_stick_x;
         this.gamepad1RightStickY = gamepad1.right_stick_y;
         this.gamepad1LeftStickX = gamepad1.left_stick_x;
@@ -97,5 +99,10 @@ class JoystickValues {
         this.gamepad2RightStickY = gamepad2.right_stick_y;
         this.gamepad2LeftStickX = gamepad2.left_stick_x;
         this.gamepad2LeftStickY = gamepad2.left_stick_y;
+
+        this.gamepad1LeftTrigger = gamepad1.left_trigger;
+        this.gamepad1RightTrigger = gamepad1.right_trigger;
+        this.gamepad2LeftTrigger = gamepad2.left_trigger;
+        this.gamepad2RightTrigger = gamepad2.left_trigger;
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
@@ -9,8 +9,6 @@ import com.qualcomm.robotcore.hardware.HardwareMap;
 import com.qualcomm.robotcore.util.ElapsedTime;
 import org.firstinspires.ftc.robotcore.external.Telemetry;
 import com.qualcomm.robotcore.hardware.Gamepad;
-import com.qualcomm.robotcore.util.ElapsedTime;
-import org.firstinspires.ftc.robotcore.external.Telemetry;
 
 
 /** A completely encompassing class of all functionality of the robot. An OpMode should interface through an instance of
@@ -111,43 +109,40 @@ public class RobotManager {
         // Adjust relative wheel speeds.
 
         // Left stick Y for adjusting rear left.
-        if (gamepads.getJoystickValues().gamepad2LeftStickY > 0.5) {
-            Navigation.wheel_speeds[0] += 0.01;
+        if (gamepads.getAnalogValues().gamepad2LeftStickY > 0.5) {
+            navigation.wheel_speeds[0] += 0.01;
         }
-        if (gamepads.getJoystickValues().gamepad2LeftStickY < -0.5) {
-            Navigation.wheel_speeds[0] -= 0.01;
+        if (gamepads.getAnalogValues().gamepad2LeftStickY < -0.5) {
+            navigation.wheel_speeds[0] -= 0.01;
         }
         // Left stick X for adjusting rear right.
-        if (gamepads.getJoystickValues().gamepad2LeftStickX > 0.5) {
-            Navigation.wheel_speeds[1] += 0.01;
+        if (gamepads.getAnalogValues().gamepad2LeftStickX > 0.5) {
+            navigation.wheel_speeds[1] += 0.01;
         }
-        if (gamepads.getJoystickValues().gamepad2LeftStickX < -0.5) {
-            Navigation.wheel_speeds[1] -= 0.01;
+        if (gamepads.getAnalogValues().gamepad2LeftStickX < -0.5) {
+            navigation.wheel_speeds[1] -= 0.01;
         }
         // Right stick Y for adjusting front left.
-        if (gamepads.getJoystickValues().gamepad2RightStickY > 0.5) {
-            Navigation.wheel_speeds[2] += 0.01;
+        if (gamepads.getAnalogValues().gamepad2RightStickY > 0.5) {
+            navigation.wheel_speeds[2] += 0.01;
         }
-        if (gamepads.getJoystickValues().gamepad2RightStickY < -0.5) {
-            Navigation.wheel_speeds[2] -= 0.01;
+        if (gamepads.getAnalogValues().gamepad2RightStickY < -0.5) {
+            navigation.wheel_speeds[2] -= 0.01;
         }
         // Right stick X for adjusting front right.
-        if (gamepads.getJoystickValues().gamepad2RightStickX > 0.5) {
-            Navigation.wheel_speeds[3] += 0.01;
+        if (gamepads.getAnalogValues().gamepad2RightStickX > 0.5) {
+            navigation.wheel_speeds[3] += 0.01;
         }
-        if (gamepads.getJoystickValues().gamepad2RightStickX < -0.5) {
-            Navigation.wheel_speeds[3] -= 0.01;
+        if (gamepads.getAnalogValues().gamepad2RightStickX < -0.5) {
+            navigation.wheel_speeds[3] -= 0.01;
         }
-
-
 
         robot.telemetry.addData("Front Motor Relative Speeds", "left (%.2f), right (%.2f)",
-                Navigation.wheel_speeds[2], Navigation.wheel_speeds[3]);
+                navigation.wheel_speeds[2], navigation.wheel_speeds[3]);
         robot.telemetry.addData("Rear Motor Relative Speeds", "left (%.2f), right (%.2f)",
-                Navigation.wheel_speeds[0], Navigation.wheel_speeds[1]);
+                navigation.wheel_speeds[0], navigation.wheel_speeds[1]);
         robot.telemetry.addData("Fine movement", "" + robot.fineMovement);
         robot.telemetry.addData("Fine rotation", "" + robot.fineRotation);
-
 
         previousStateGamepads.copyGamepads(gamepads);
     }
@@ -163,7 +158,9 @@ public class RobotManager {
     /** Changes drivetrain motor inputs based off the controller inputs.
      */
     public void maneuver() {
-
+        if (!navigation.updateStrafePower(gamepads.getAnalogValues(), robot)) {
+            return;
+        }
         boolean movedStraight = navigation.moveStraight(
                 gamepads.getButtonState(GamepadWrapper.DriverAction.MOVE_STRAIGHT_FORWARD),
                 gamepads.getButtonState(GamepadWrapper.DriverAction.MOVE_STRAIGHT_BACKWARD),
@@ -172,7 +169,7 @@ public class RobotManager {
                 robot
         );
         if (!movedStraight) {
-            navigation.maneuver(gamepads.getJoystickValues(), robot);
+            navigation.maneuver(gamepads.getAnalogValues(), robot);
         }
     }
 


### PR DESCRIPTION
This aims to fix the issue of the robot accelerating and decelerating too fast while being teleoperated, which may still be an issue after adjusting the robot's weight distribution.

This makes the left trigger on gamepad 1 control the speed at which the robot strafes (multiplied by the fine and coarse movement constants), so that the left joystick and D-Pad now only control strafe direction, not power. Turning with the right joystick is unaffected.

In my opinion, it will be easier for the driver to be smooth while accelerating and decelerating the robot if the throttle is controlled by the left trigger than by the distance from the center of the left joystick. Additionally, the previous issue of it being impossible to accelerate and decelerate smoothly while using the D-Pad is fixed here.