### PR TITLE
Linear acceleration for strafing and rotating

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -328,24 +328,6 @@ public class Navigation
         }
     }
 
-    /** Determines the minimum strafing speed of the robot
-     *
-     *  @param strafeAngle the direction (angle) in which the robot should strafe
-     *  @return the minimum strafing speed of the robot
-     */
-    private double getMinStrafeSpeed(double strafeAngle) {
-        return getRobotSpeed(strafeAngle, MIN_STRAFE_POWER);
-    }
-
-    /** Determines the maximum strafing speed of the robot
-     *
-     *  @param strafeAngle the direction (angle) in which the robot should strafe
-     *  @return the minimum strafing speed of the robot
-     */
-    private double getMaxStrafeSpeed(double strafeAngle) {
-        return getRobotSpeed(strafeAngle, MAX_STRAFE_POWER);
-    }
-
     /** Calculates half the amount of time it is estimated for a linear strafe to take.
      *
      *  @param distance the distance of the strafe
@@ -353,8 +335,8 @@ public class Navigation
      */
     private double getHalfStrafeTime(double distance, double strafeAngle) {
         // Inches per second is probably a good unit.
-        double min_strafe_speed = getMinStrafeSpeed(strafeAngle);
-        double max_strafe_speed = getMaxStrafeSpeed(strafeAngle);
+        double min_strafe_speed = getRobotSpeed(strafeAngle, MIN_STRAFE_POWER);
+        double max_strafe_speed = getRobotSpeed(strafeAngle, MAX_STRAFE_POWER);
 
         double ramp_distance = (max_strafe_speed + min_strafe_speed) / 2
                              * (max_strafe_speed - min_strafe_speed) / STRAFE_ACCELERATION;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -4,6 +4,7 @@
 package org.firstinspires.ftc.teamcode;
 
 
+import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.Range;
 
 import java.util.ArrayList;
@@ -264,46 +265,48 @@ public class Navigation
      *  @param target The desired position of the robot.
      */
     public void travelLinear(Point target, Robot robot) {
-//        robot.positionManager.updatePosition(robot);
-//        final Point startLoc = robot.getPosition().getLocation();
-//        Point currentLoc = new Point(startLoc.x, startLoc.y, "current");
-//
-//        double totalDistance = getEuclideanDistance(startLoc, target);
-//
-//        double power = MIN_STRAFE_POWER;
-//        double distanceToTarget = getEuclideanDistance(currentLoc, target);
-//        double distanceTraveled = getEuclideanDistance(startLoc, currentLoc);
-//
-//        while (distanceToTarget > EPSILON_LOC) {
-//
-//            if (distanceTraveled < totalDistance / 2) {
-//                // Ramping up.
-//                power = Range.clip(
-//                        (distanceTraveled / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER,
-//                        MIN_STRAFE_POWER, MAX_STRAFE_POWER);
-//            }
-//            else {
-//                // Ramping down.
-//                power = Range.clip(
-//                        (distanceToTarget / STRAFE_RAMP_DISTANCE) * MAX_STRAFE_POWER,
-//                        MIN_STRAFE_POWER, MAX_STRAFE_POWER);
-//            }
-//
-//            setDriveMotorPowers(getAngleBetween(currentLoc, target), power, 0.0, robot, false);
-//
-//            robot.positionManager.updatePosition(robot);
-//            currentLoc = robot.getPosition().getLocation();
-//
-//            distanceToTarget = getEuclideanDistance(currentLoc, target);
-//            distanceTraveled = getEuclideanDistance(startLoc, currentLoc);
-//
-//            robot.telemetry.addData("X", currentLoc.x);
-//            robot.telemetry.addData("Y", currentLoc.y);
-//            robot.telemetry.addData("dX", target.x);
-//            robot.telemetry.addData("dY", target.y);
-//            robot.telemetry.update();
-//        }
-//        stopMovement(robot);
+        robot.positionManager.updatePosition(robot);
+        final Point startLoc = robot.getPosition().getLocation();
+        Point currentLoc = new Point(startLoc.x, startLoc.y, "current");
+        double startingTime = robot.elapsedTime.milliseconds();
+
+        double totalDistance = getEuclideanDistance(startLoc, target);
+        double halfStrafeTime = getHalfStrafeTime(totalDistance, getAngleBetween(startLoc, target));
+
+        double power = MIN_STRAFE_POWER;
+        double timeElapsed = 0;
+        double timeLeft = 2 * halfStrafeTime - timeElapsed;
+
+        while (timeElapsed < 2*halfStrafeTime) {
+
+            if (timeElapsed < halfStrafeTime) {
+                // Ramping up.
+                power = Range.clip(
+                        (timeElapsed / halfStrafeTime) * MAX_STRAFE_POWER,
+                        MIN_STRAFE_POWER, MAX_STRAFE_POWER);
+            }
+            else {
+                // Ramping down.
+                power = Range.clip(
+                        (timeLeft / halfStrafeTime) * MAX_STRAFE_POWER,
+                        MIN_STRAFE_POWER, MAX_STRAFE_POWER);
+            }
+
+            setDriveMotorPowers(getAngleBetween(currentLoc, target), power, 0.0, robot, false);
+
+            robot.positionManager.updatePosition(robot);
+            currentLoc = robot.getPosition().getLocation();
+
+            timeElapsed = robot.elapsedTime.milliseconds()-startingTime;
+            timeLeft = 2 * halfStrafeTime - timeElapsed;
+
+            robot.telemetry.addData("X", currentLoc.x);
+            robot.telemetry.addData("Y", currentLoc.y);
+            robot.telemetry.addData("dX", target.x);
+            robot.telemetry.addData("dY", target.y);
+            robot.telemetry.update();
+        }
+        stopMovement(robot);
     }
 
     /** Calculates the speed of the robot when strafing given the direction of strafing and the strafing speed

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -306,7 +306,7 @@ public class Navigation
 //        stopMovement(robot);
     }
 
-    /** Calculates the speed of the robot when strafing given the direction of strafing and the strafing spead
+    /** Calculates the speed of the robot when strafing given the direction of strafing and the strafing speed
      *
      *  @param strafeAngle the direction (angle) in which the robot should strafe
      *  @param power the strafing speed of the robot
@@ -317,14 +317,11 @@ public class Navigation
         double powerSet2 = Math.sin(strafeAngle) - Math.cos(strafeAngle);
         double[] rawPowers = scaleRange(powerSet1, powerSet2);
 
-        //TODO: the usage of averageMotorSpeed might need to be changed, not sure yet
-        double averageMotorSpeed = (wheel_speeds[0] + wheel_speeds[1] + wheel_speeds[2] + wheel_speeds[3]) / 4;
-
         if (strafeAngle > -Math.PI/2 && strafeAngle < Math.PI/2) {
-            return (SPEED_FACTOR * power * averageMotorSpeed * Math.sqrt(2 * Math.pow(rawPowers[1]/rawPowers[0], 2) + 2)) / 2;
+            return (SPEED_FACTOR * power * Math.sqrt(2 * Math.pow(rawPowers[1]/rawPowers[0], 2) + 2)) / 2;
         }
         else {
-            return (SPEED_FACTOR * power * averageMotorSpeed * Math.sqrt(2 * Math.pow(rawPowers[0]/rawPowers[1], 2) + 2)) / 2;
+            return (SPEED_FACTOR * power * Math.sqrt(2 * Math.pow(rawPowers[0]/rawPowers[1], 2) + 2)) / 2;
         }
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -25,6 +25,7 @@ public class Navigation
     // How many inches per second the robot goes at when moving forward with all motors set to full power.
     // TODO: empirically measure this value.
     final double SPEED_FACTOR = 1.0;
+    final double ROTATION_RADIUS = 1.0; // Radius of the robot's rotation (still needs to be calculated)
     final double MAX_STRAFE_POWER = 1.0;
     final double MIN_STRAFE_POWER = 0.2;
     final double MAX_ROTATE_POWER = 0.5;
@@ -347,6 +348,27 @@ public class Navigation
         else {  // We never get to max_strafe_speed
             return (-min_strafe_speed + Math.sqrt(Math.pow(min_strafe_speed, 2) + distance * STRAFE_ACCELERATION))
                  / 0.5 * STRAFE_ACCELERATION;
+        }
+    }
+
+    /** Calculates half the amount of time it is estimated for a rotation to take.
+     *
+     *  @param angle The angle of the rotation
+     */
+    private double getHalfRotateTime(double angle) {
+        // Get this in inches per second but convert to radians per second
+        double min_rotate_speed = (SPEED_FACTOR * MIN_ROTATE_POWER) / ROTATION_RADIUS;
+        double max_rotate_speed = (SPEED_FACTOR * MAX_ROTATE_POWER) / ROTATION_RADIUS;
+
+        double ramp_angle = (max_rotate_speed + min_rotate_speed) / 2
+                * (max_rotate_speed - min_rotate_speed) / ROTATE_ACCELERATION;
+        if (distance / 2 >= ramp_angle) {
+            return (distance / 2 - ramp_angle) / max_rotate_speed
+                    + (max_rotate_speed - min_rotate_speed) / ROTATE_ACCELERATION;
+        }
+        else {  // We never get to max_rotate_speed
+            return (-min_rotate_speed + Math.sqrt(Math.pow(min_rotate_speed, 2) + angle * ROTATE_ACCELERATION))
+                    / 0.5 * ROTATE_ACCELERATION;
         }
     }
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Navigation.java
@@ -306,16 +306,55 @@ public class Navigation
 //        stopMovement(robot);
     }
 
+    /** Calculates the speed of the robot when strafing given the direction of strafing and the strafing spead
+     *
+     *  @param strafeAngle the direction (angle) in which the robot should strafe
+     *  @param power the strafing speed of the robot
+     *  @return the speed of the robot
+     */
+    private double getRobotSpeed(double strafeAngle, double power) {
+        double powerSet1 = Math.sin(strafeAngle) + Math.cos(strafeAngle);
+        double powerSet2 = Math.sin(strafeAngle) - Math.cos(strafeAngle);
+        double[] rawPowers = scaleRange(powerSet1, powerSet2);
+
+        //TODO: the usage of averageMotorSpeed might need to be changed, not sure yet
+        double averageMotorSpeed = (wheel_speeds[0] + wheel_speeds[1] + wheel_speeds[2] + wheel_speeds[3]) / 4;
+
+        if (strafeAngle > -Math.PI/2 && strafeAngle < Math.PI/2) {
+            return (SPEED_FACTOR * power * averageMotorSpeed * Math.sqrt(2 * Math.pow(rawPowers[1]/rawPowers[0], 2) + 2)) / 2;
+        }
+        else {
+            return (SPEED_FACTOR * power * averageMotorSpeed * Math.sqrt(2 * Math.pow(rawPowers[0]/rawPowers[1], 2) + 2)) / 2;
+        }
+    }
+
+    /** Determines the minimum strafing speed of the robot
+     *
+     *  @param strafeAngle the direction (angle) in which the robot should strafe
+     *  @return the minimum strafing speed of the robot
+     */
+    private double getMinStrafeSpeed(double strafeAngle) {
+        return getRobotSpeed(strafeAngle, MIN_STRAFE_POWER);
+    }
+
+    /** Determines the maximum strafing speed of the robot
+     *
+     *  @param strafeAngle the direction (angle) in which the robot should strafe
+     *  @return the minimum strafing speed of the robot
+     */
+    private double getMaxStrafeSpeed(double strafeAngle) {
+        return getRobotSpeed(strafeAngle, MAX_STRAFE_POWER);
+    }
+
     /** Calculates half the amount of time it is estimated for a linear strafe to take.
      *
      *  @param distance the distance of the strafe
      *  @param strafeAngle the angle of the strafe
      */
     private double getHalfStrafeTime(double distance, double strafeAngle) {
-        // TODO: these need to be calculated using the strafe angle motor power constants, and SPEED_FACTOR.
         // Inches per second is probably a good unit.
-        double min_strafe_speed = 0.0;
-        double max_strafe_speed = 0.0;
+        double min_strafe_speed = getMinStrafeSpeed(strafeAngle);
+        double max_strafe_speed = getMaxStrafeSpeed(strafeAngle);
 
         double ramp_distance = (max_strafe_speed + min_strafe_speed) / 2
                              * (max_strafe_speed - min_strafe_speed) / STRAFE_ACCELERATION;

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/RobotManager.java
@@ -27,7 +27,7 @@ public class RobotManager {
 
     private GamepadWrapper gamepads, previousStateGamepads;
 
-    private Telemetry telemetry;
+    private Telemetry telemetry;  // TODO: Create wrapper object so update doesn't clear.
     private ElapsedTime elapsedTime;
 
     public RobotManager(HardwareMap hardwareMap, Gamepad gamepad1, Gamepad gamepad2,


### PR DESCRIPTION
This pull request implements linear acceleration based on time for strafing (in `travelLinear` method) and rotating (in `rotate` method). This is done in order to fix the issue of the robot accelerating in a quadratic manner.

- Added `getHalfRotateTime` method to find half the amount of time it takes to rotate.
- Added `getHalfStrafeTime` method to find half the amount of time it takes to strafe.
- Added `getRobotSpeed` method to find the speed of the robot based on the angle and power. This is used in the `getHalfStrafeTime` method for the miminum and maximum speeds of the robot, which are used in the time calculations.